### PR TITLE
[abi][readme] Fix links to issue tracker.

### DIFF
--- a/abi/README.md
+++ b/abi/README.md
@@ -3,8 +3,8 @@
 ## Defects report
 
 Please report defects in the specifications in this folder to the
-`issue tracker page on GitHub
-<https://github.com/ARM-software/software-standards/issues>`_.
+[issue tracker page on
+GitHub](https://github.com/ARM-software/software-standards/issues).
 
 ## Available documents
 

--- a/abi/aapcs64/README.md
+++ b/abi/aapcs64/README.md
@@ -32,5 +32,5 @@ claims.
 
 Please report defects in the [Procedure Call Standard use by the
 Application Binary Interface (ABI) for the Arm 64-bit architecture
-(AArch64)](aapcs64.rst) to the `issue tracker page on GitHub
-<https://github.com/ARM-software/software-standards/issues>`_.
+(AArch64)](aapcs64.rst) to the [issue tracker page on
+GitHub](https://github.com/ARM-software/software-standards/issues).

--- a/abi/vfabia64/README.md
+++ b/abi/vfabia64/README.md
@@ -30,6 +30,6 @@ claims.
 ## Defects report
 
 Please report defects in the [Vector Function Application Binary
-Interface Specification for AArch64](vfabia64.rst) to the `issue
-tracker page on GitHub
-<https://github.com/ARM-software/software-standards/issues>`_.
+Interface Specification for AArch64](vfabia64.rst) to the [issue
+tracker page on
+GitHub](https://github.com/ARM-software/software-standards/issues).


### PR DESCRIPTION
The links were specified using rST syntax instead of Markdown syntax.