### PR TITLE
Update C++ mangling to reflect existing practice

### DIFF
--- a/abi/aapcs64/aapcs64.rst
+++ b/abi/aapcs64/aapcs64.rst
@@ -1384,7 +1384,7 @@ The header file ``arm_neon.h`` also defines a number of intrinsic functions that
 C++ Mangling
 ------------
 
-For C++ mangling purposes the user-friendly names are treated as though the equivalent internal name was specified. Thus the function
+For C++ mangling purposes the user-friendly names are treated as though the equivalent internal name was specified. Unless the platform ABI specifies otherwise, the types are treated as *vendor extended types*, prefixed by ``u``. For example:
 
 .. code:: c
 
@@ -1396,6 +1396,11 @@ is mangled as
 
     _Z1fu10__Int8x8_t
 
+A platform ABI may instead choose to treat the types as normal structure types, without a ``u`` prefix. For example, a platform ABI may choose to mangle the function above as:
+
+    :c:`_Z1f10__Int8x8_t`
+
+instead.
 
 APPENDIX Variable argument Lists
 ================================


### PR DESCRIPTION
The AAPCS64 said that:

   void f(int8x8_t)

should be mangled as:

   _Z1fu10__Int8x8_t

(with a 'u', using the namespace for vendor extensions).  But both
GCC and clang mangle it as:

   _Z1f10__Int8x8_t

(without the 'u').  What clang and GCC do is now the de factor ABI
for many platforms, so this patch adds it as an allowable variation.

(We shouldn't just change the base ABI, since that would be unfair on
anyone who has implemented the original specification correctly for
their platform.)