### PR TITLE
[aapcs64] Change size_t and ptrdiff_t definitions

### DIFF
--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -2951,9 +2951,9 @@ Both C and C++ require that a system provide additional type definitions that ar
   +-----------------+------------------+----------------+---------------------+
   | Typedef         | ILP32 **(Beta)** | LP64           | LLP64               |
   +=================+==================+================+=====================+
-  | ``size_t``      | unsigned long    | unsigned long  | unsigned long long  |
+  | ``size_t``      | unsigned int     | unsigned long  | unsigned long long  |
   +-----------------+------------------+----------------+---------------------+
-  | ``ptrdiff_t``   | signed long      | signed long    | signed long long    |
+  | ``ptrdiff_t``   | signed int       | signed long    | signed long long    |
   +-----------------+------------------+----------------+---------------------+
 
 Definition of va\_list


### PR DESCRIPTION
The current [definition](https://github.com/ARM-software/abi-aa/blob/ee6b627a58988b56a761d1a3d545fc01b9b78241/aapcs64/aapcs64.rst?plain=1#L2954) of `size_t` as `unsigned long` causes many problems with recent versions of gcc and glibc* and other software packages. When `size_t` is defined like this gcc issues warnings/errors when a pointer to a `size_t` variable is to be assigned to a `uint32_t *` variable (`uint32_t` is [defined](https://sourceware.org/git?p=glibc.git;a=blob;f=posix/bits/types.h;hb=d6c2760ef7f7cdeab912767f04db4b14632fbb5f#l42) [as](https://sourceware.org/git?p=glibc.git;a=blob;f=bits/stdint-uintn.h;hb=d6c2760ef7f7cdeab912767f04db4b14632fbb5f#l26) `unsigned int`) even though both `unsigned long int` and `unsigned int` are the same size (4 bytes).

Two other ILP32 ABIs supported in the gcc and glibc (i.e. [MIPS n32](https://gcc.gnu.org/git?p=gcc.git;a=blob;f=gcc/config/mips/mips.h;hb=2f2e9bcfb0fd9cbf46e2d0d03b3f32f7df8d4fff#l3112) and [Intel x32](https://gcc.gnu.org/git?p=gcc.git;a=blob;f=gcc/config/i386/x86-64.h;hb=2f2e9bcfb0fd9cbf46e2d0d03b3f32f7df8d4fff#l40)) define `size_t` as `unsigned int`.

\* both need to be patched to support AArch64 ILP32, but the problems creep
    into more platform independent code