### PR TITLE
[aadwarf64]] Add DW_CFA_AARCH64_set_ra_state stack frame operation

### DIFF
--- a/aadwarf64/aadwarf64.rst
+++ b/aadwarf64/aadwarf64.rst
@@ -522,7 +522,7 @@ integers.
    .. _Note 9:
 
    9. Normally, the program counter is restored from the return address, however
-      having both LR and PC diversifiers are useful for describing asynchronously
+      having both LR and PC diversifiers is useful for describing asynchronously
       created stack frames. A DWARF expression may use this register to restore
       the context in case of a signal context.
 
@@ -634,23 +634,30 @@ This ABI defines the following vendor call frame instructions:
    | ``DW_CFA_AARCH64_set_ra_state`` (**Alpha**)                 | 0           | ``0x2B``   | ULEB128 ra_state | SLEB128 offset |
    +-------------------------------------------------------------+-------------+------------+------------------+----------------+
 
-The ``DW_CFA_AARCH64_negate_ra_state`` operation toggles between the
+The ``DW_CFA_AARCH64_negate_ra_state`` instruction toggles between the
 ``DW_AARCH64_RA_NOT_SIGNED`` and ``DW_AARCH64_RA_SIGNED_SP`` return address
 states in RA_SIGN_STATE pseudo-register. It does not take any operands.
 
-The ``DW_CFA_AARCH64_set_ra_state`` instruction takes two operands; an unsigned
-LEB128 value representing a return address state ra_state and a signed LEB128
+The ``DW_CFA_AARCH64_set_ra_state`` instruction takes two operands: an unsigned
+LEB128 value representing a return address state ra_state; and a signed LEB128
 factored offset. The required action is to set the RA_SIGN_STATE pseudo-register
 to the ra_state value and if the ra_state value is ``DW_AARCH64_RA_SIGNED_SP_PC``
 to capture the current code location + (offset * ``code_alignment_factor``)
 as the signing/authenticating PAC instruction, otherwise it is has the value 0.
 The code location information can be used for authenticating the return address.
 
-The ``DW_CFA_AARCH64_negate_ra_state_with_pc`` operation toggles between the
+The ``DW_CFA_AARCH64_negate_ra_state_with_pc`` instruction toggles between the
 ``DW_AARCH64_RA_NOT_SIGNED`` and ``DW_AARCH64_RA_SIGNED_SP_PC`` return
 address state in RA_SIGN_STATE pseudo-register, and instructs the unwinder to
 capture the current code location. The code location information can be used
 for authenticating the return address.
+
+The ``DW_CFA_AARCH64_negate_ra_state_with_pc`` instruction is **Deprecated**
+and the ``DW_CFA_AARCH64_set_ra_state`` instruction should be used instead.
+
+*The ``DW_CFA_AARCH64_negate_ra_state`` instruction is deprecated because it is
+unable to correctly represent the return address signing state when the code
+flow is not linear between the signing/authenticating PAC instructions.*
 
 The ``DW_CFA_AARCH64_negate_ra_state_with_pc`` instruction must be placed within
 the debug frame in a position that refers to the exact code location of the


### PR DESCRIPTION
The DW_CFA_AARCH64_set_ra_state operation updates the RA_SIGN_STATE pseudo register with the current signing state. If the signing state includes signing is DW_AARCH64_RA_SIGNED_SP_PC, then it also provides the offset to the signing instruction so that the PC value used in the signing can be calculated.

The DW_CFA_AARCH64_negate_ra_state_with_pc operation has been marked as deprecated.  This is because it has been found that it is not suitable for describing all cases where the PC was used to sign the return address (see https://github.com/ARM-software/abi-aa/issues/327)

The contents of the RA_SIGN_STATE pseudo register is also changed from being described in terms of a set of bits to being a series of defined values.

Previously the state of the RA_SIGN_STATE pseudo register was changed implicitly by the DW_CFA_AARCH64_negate_ra_state and DW_CFA_AARCH64_set_ra_state operations. This meant that the actual encoding was actually internal to any implementation.

Now with the introduction of the DW_CFA_AARCH64_set_ra_state operation the encoding has been made externally visible.  So the opportunity has been taken now to change the encoding to a simpler form.