### PR TITLE
[atomicsabi64] Document release fence using ISHST+ISHLD barriers

### DIFF
--- a/atomicsabi64/atomicsabi64.rst
+++ b/atomicsabi64/atomicsabi64.rst
@@ -411,6 +411,9 @@ Synchronization Fences
   | ``atomic_thread_fence(seq_cst)``                    |    DMB ISH                           |
   +-----------------------------------------------------+--------------------------------------+
 
+The release fence has two alternative implementations.  Using ``DMB ISHLD`` and ``DMB ISHST``
+allows for more reordering since the combination is not a store-load barrier.
+
 32-bit types
 ------------
 


### PR DESCRIPTION
This allows more reordering than ISH.