### PR TITLE
[CI] Add apt update prior to using apt install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
+    - name: update repositories
+      run: sudo apt update
     - name: install libcairo-dev
       run: sudo apt install -y libcairo-dev
     - name: install packages


### PR DESCRIPTION
In https://github.com/ARM-software/abi-aa/pull/355 we added an apt install for libcairo for the benefit of pycairo. In that PR we did not add an apt update prior to the apt install and it looks like this is required as apt install is now failing with some out of date repository URLs.