### PR TITLE
[pauthabi64] Require 0 addend for signing of undefined weak ref

### DIFF
--- a/pauthabielf64/pauthabielf64.rst
+++ b/pauthabielf64/pauthabielf64.rst
@@ -678,9 +678,10 @@ this should be sufficient.
   be set to 0 by a producer. A consumer must not assume that reserved
   bits are set to 0.
 
-For a relocation that involves signing a pointer, if the target symbol
-is an undefined weak reference, the result of the
-relocation is 0 (nullptr) regardless of the signing schema.
+For a relocation that involves signing a pointer, and the relocation
+addend is 0, if the target symbol is an undefined weak reference, the
+result of the relocation is 0 (nullptr) regardless of the signing
+schema.
 
 The computation to form the ``modifier`` is the same as
 ARM64E_. ``Place`` is the relocation target address.

--- a/pauthabielf64/pauthabielf64.rst
+++ b/pauthabielf64/pauthabielf64.rst
@@ -678,10 +678,10 @@ this should be sufficient.
   be set to 0 by a producer. A consumer must not assume that reserved
   bits are set to 0.
 
-For a relocation that involves signing a pointer, and the relocation
-addend is 0, if the target symbol is an undefined weak reference, the
-result of the relocation is 0 (nullptr) regardless of the signing
-schema.
+For a relocation that involves signing a pointer, if the target symbol
+is an undefined weak reference, the result of the relocation is not
+signed. If the relocation addend is 0, this means the result of the
+relocation is 0 (nullptr) regardless of the signing schema.
 
 The computation to form the ``modifier`` is the same as
 ARM64E_. ``Place`` is the relocation target address.


### PR DESCRIPTION
Clarify that undefined weak-references are unsigned.

The intent was that null-pointers could be easily tested for without worrying about signing schemas, if there is an unresolved weak-reference with a non-zero addend then the resulting value doesn't make a lot of sense, signed or unsigned. In practice to use a weak-reference with an addend it must be tested first with a zero addend.

if (weak) {
  use weak->addend;
}

Raised from: https://github.com/llvm/llvm-project/issues/173296