### PR TITLE
atomicsabi64: add store_add mappings for non-returning reductions

### DIFF
--- a/atomicsabi64/atomicsabi64.rst
+++ b/atomicsabi64/atomicsabi64.rst
@@ -320,7 +320,7 @@ further detailed in `Special Cases`_.
 
 Only some variants of ``fetch_<op>`` and ``store_<op>`` are listed since the
 mappings are identical except for a different ``<op>``. ``store_<op>`` is the
-non-returning form of ``fetch_<op>`` and, like ``store``, only admits the
+non-returning form of ``fetch_<op>`` and, like ``store``, only allows the
 ``relaxed``, ``release`` and ``seq_cst`` memory orders.
 
 Atomic operations and Memory Order are abbreviated as follows:
@@ -347,6 +347,8 @@ Atomic operations and Memory Order are abbreviated as follows:
   | ``atomic_fetch_xor_explicit(...)``                 | ``fetch_xor(...)``                   |
   +----------------------------------------------------+--------------------------------------+
   | ``atomic_fetch_and_explicit(...)``                 | ``fetch_and(...)``                   |
+  +----------------------------------------------------+--------------------------------------+
+  | ``atomic_store_add_explicit(...)``                 | ``store_add(...)``                   |
   +----------------------------------------------------+--------------------------------------+
 
 .. table::

--- a/atomicsabi64/atomicsabi64.rst
+++ b/atomicsabi64/atomicsabi64.rst
@@ -318,8 +318,10 @@ Arbitrary registers may be used in the mappings. Instructions marked with ``*``
 in the tables cannot use ``WZR`` or ``XZR`` as a destination register. This is
 further detailed in `Special Cases`_.
 
-Only some variants of ``fetch_<op>`` are listed since the mappings are identical
-except for a different ``<op>``.
+Only some variants of ``fetch_<op>`` and ``store_<op>`` are listed since the
+mappings are identical except for a different ``<op>``. ``store_<op>`` is the
+non-returning form of ``fetch_<op>`` and, like ``store``, only admits the
+``relaxed``, ``release`` and ``seq_cst`` memory orders.
 
 Atomic operations and Memory Order are abbreviated as follows:
 
@@ -555,6 +557,30 @@ returned in ``W0``.
   |                                     | ``FEAT_LSE``  | .. code-block:: none                 |
   |                                     |               |                                      |
   |                                     |               |    LDADDAL W2, W0, [X1] *            |
+  +-------------------------------------+---------------+--------------------------------------+
+  | ``store_add(loc,val,relaxed)``      | ``Armv8-A``   | .. code-block:: none                 |
+  |                                     |               |                                      |
+  |                                     |               |    loop:                             |
+  |                                     |               |      LDXR   W0, [X1]                 |
+  |                                     |               |      ADD    W2, W2, W0               |
+  |                                     |               |      STXR   W3, W2, [X1]             |
+  |                                     |               |      CBNZ   W3, loop                 |
+  |                                     +---------------+--------------------------------------+
+  |                                     | ``FEAT_LSE``  | .. code-block:: none                 |
+  |                                     |               |                                      |
+  |                                     |               |    STADD   W2, [X1]                  |
+  +-------------------------------------+---------------+--------------------------------------+
+  | ``store_add(loc,val,release)``      | ``Armv8-A``   | .. code-block:: none                 |
+  | ``store_add(loc,val,seq_cst)``      |               |                                      |
+  |                                     |               |    loop:                             |
+  |                                     |               |      LDXR   W0, [X1]                 |
+  |                                     |               |      ADD    W2, W2, W0               |
+  |                                     |               |      STLXR  W3, W2, [X1]             |
+  |                                     |               |      CBNZ   W3, loop                 |
+  |                                     +---------------+--------------------------------------+
+  |                                     | ``FEAT_LSE``  | .. code-block:: none                 |
+  |                                     |               |                                      |
+  |                                     |               |    STADDL  W2, [X1]                  |
   +-------------------------------------+---------------+--------------------------------------+
   | ``compare_exchange_strong(``        | ``Armv8-A``   | .. code-block:: none                 |
   |   ``loc,exp,val,relaxed,relaxed)``  |               |                                      |


### PR DESCRIPTION
The GRACE CPU compiler team (Soumya AR, Matthew Malcomson) have been adding mappings for a new instruction. We helped test it and figure its worth adding to the ABI, so others can benefit given the ABI is one central place people look for such mappings.

The NVIDIA memory model team recently proposed to add a new atomic reduction operation: `store_add`. This is recorded in https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3111r0.html

Which is now in the standards: https://eel.is/c++draft/atomics

This commit adds AArch64 mappings for the reduction alongside the existing fetch_add rows:

  relaxed          -> STADD  (FEAT_LSE) / LDXR;ADD;STXR;CBNZ  (Armv8-A)
  release, seq_cst -> STADDL (FEAT_LSE) / LDXR;ADD;STLXR;CBNZ (Armv8-A)

store_<op> is the non-returning form of fetch_<op> and, like store, only admits the relaxed/release/seq_cst memory orders (P3111R0 precondition: non-returning, so no acquire/acq_rel). STADD/STADDL are not marked '*' because the non-returning (WZR-destination) behaviour is the intended semantics here, unlike the unused-result LD<OP> case in Special Cases.

We tested that these mappings are sound here: https://github.com/hernanponcedeleon/Dat3M/issues/984

Using Telechat to turn C/C++ tests into Asm tests that exercise the new mapping. We use the Dartagnan to simulate the src and tgt. Thanks to Thomas Haas and Hernan PonceDeLeon on their great work getting Dartagnan ready to handle such things.

Related toolchain work implementing P3111 (same non-returning relaxed/release/seq_cst semantics):
  LLVM storermw IR (lowers to STADD/STADDL):
    https://github.com/llvm/llvm-project/pull/207048
  LLVM libc++ P3111 implementation:
    https://github.com/llvm/llvm-project/pull/186935
  GCC atomic reduction infrastructure:
    https://inbox.sourceware.org/gcc-patches/20260610140816.19947-1-soumyaa@nvidia.com/

We'd love to hear your thoughts!